### PR TITLE
Makes concrete UMD/node friendly by not force-checking the window var

### DIFF
--- a/src/concrete.js
+++ b/src/concrete.js
@@ -1,16 +1,16 @@
 var Concrete = {},
     idCounter = 0;
 
-Concrete.PIXEL_RATIO = (function() {
+Concrete.PIXEL_RATIO = (function(win) {
   // client browsers
-  if (window && window.navigator && window.navigator.userAgent && !/PhantomJS/.test(window.navigator.userAgent)) {
+  if (win && win.navigator && win.navigator.userAgent && !/PhantomJS/.test(win.navigator.userAgent)) {
     return 2;
   }
   // headless browsers
   else {
     return 1;
   }
-})();
+})(typeof window !== 'undefined' ? window : null);
 
 Concrete.viewports = [];
 


### PR DESCRIPTION
Currently, concrete sets up the pixel ratio by explicitly looking at window inside of an IFFE.

We need to test for window before we use it, as babel/webpack environments will simply complain that window is not defined. This fix uses a pattern similar to that in webpack 3's UMD signature, testing for `window` via a safe typeof, and then passing either `window` or `null` to the IFFE.